### PR TITLE
DarkTreeView rendering optimization.

### DIFF
--- a/DarkUI/Controls/DarkTreeView.cs
+++ b/DarkUI/Controls/DarkTreeView.cs
@@ -1262,10 +1262,33 @@ namespace DarkUI.Controls
             }
 
             // 5. Draw child nodes
+            DrawChildNodes(node, g);
+            
+        }
+        
+        /// <summary>
+        /// Recursively paints only the nodes and child nodes within the viewport.
+        /// </summary>
+        private void DrawChildNodes(DarkTreeNode node, Graphics g)
+        {
             if (node.Expanded)
             {
                 foreach (var childNode in node.Nodes)
-                    DrawNode(childNode, g);
+                {
+
+                    if (childNode.Expanded)
+                        DrawChildNodes(childNode, g);
+
+                    bool isInTopView = Viewport.Top <= childNode.FullArea.Y;  
+                    bool isWithin = childNode.FullArea.Y < Viewport.Top + Viewport.Height;
+                    bool isPastBottomView = childNode.FullArea.Y > Viewport.Top + Viewport.Height;
+
+                    if (isInTopView && isWithin)
+                        DrawNode(childNode, g);
+
+                    if (isPastBottomView)
+                        break;
+                }
             }
         }
 


### PR DESCRIPTION
Optimized the drawing of child nodes. It'll perform similar to listview, drawing only the visible elements within the viewport, thus making the scrolling smooth. With support for each child nodes.

---

Might want to change:
```
bool isInTopView = Viewport.Top <= childNode.FullArea.Y;
```
To:
```
bool isInTopView = Viewport.Top <= childNode.FullArea.Y + ItemHeight;
```
As the first visible node it's not drawn sometimes.