### PR TITLE
Fix crash when ComboBox is minimized

### DIFF
--- a/DarkUI/Controls/DarkComboBox.cs
+++ b/DarkUI/Controls/DarkComboBox.cs
@@ -104,6 +104,8 @@ namespace DarkUI.Controls
 
         private void PaintCombobox()
         {
+            if (ClientRectangle.Width <= 0 || ClientRectangle.Height <= 0)
+                _buffer = new Bitmap(1, 1);
             if (_buffer == null)
                 _buffer = new Bitmap(ClientRectangle.Width, ClientRectangle.Height);
 


### PR DESCRIPTION
When a form containing a ComboBox is minimized, the ClientRectangle's size goes to 0. This causes the initialization of the buffer for drawing the ComboBox to fail since you can't create a 0x0 bitmap.